### PR TITLE
Remove SpiritButton component from multiple pages for cleanup

### DIFF
--- a/spirit11/client/src/components/SpiritButton.jsx
+++ b/spirit11/client/src/components/SpiritButton.jsx
@@ -11,7 +11,7 @@ const SpiritButton = () => {
   return (
     <div>
       <button
-        className="bg-white text-blue-600 px-4 py-2 rounded-lg font-semibold shadow-md hover:bg-gray-200"
+        className="bg-white text-blue-600 px-4 py-2 rounded-lg font-semibold shadow-md hover:bg-gray-200 cursor-pointer"
         onClick={handleClick}
       >
         Spiriter

--- a/spirit11/client/src/pages/AddPlayer.jsx
+++ b/spirit11/client/src/pages/AddPlayer.jsx
@@ -77,7 +77,7 @@ const AddPlayer = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600 p-6">
       <NavBar />
-      <SpiritButton />
+      {/* <SpiritButton /> */}
       <div className="w-full mt-30 max-w-3xl bg-white shadow-lg rounded-lg p-8">
         <h1 className="text-3xl font-bold text-center text-gray-800 mb-6">
           Add New Player

--- a/spirit11/client/src/pages/Budget.jsx
+++ b/spirit11/client/src/pages/Budget.jsx
@@ -42,7 +42,7 @@ const Budget = () => {
   return (
     <div className="min-h-screen p-6 bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600 text-white">
       <NavBar />
-      <SpiritButton />
+      {/* <SpiritButton /> */}
       {/* Heading */}
       <h1 className="text-3xl font-bold text-center mb-6 mt-30">🏏 Budget Overview</h1>
 

--- a/spirit11/client/src/pages/Leaderboard.jsx
+++ b/spirit11/client/src/pages/Leaderboard.jsx
@@ -37,7 +37,7 @@ const Leaderboard = () => {
   return (
     <div className="min-h-screen flex flex-col items-center bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600 text-white p-5">
       <NavBar />
-      <SpiritButton />
+      {/* <SpiritButton /> */}
       <h1 className="text-4xl font-bold mb-4 mt-30">Leaderboard</h1>
       <div className="mb-4">
         <label className="mr-2">Show top:</label>

--- a/spirit11/client/src/pages/Players.jsx
+++ b/spirit11/client/src/pages/Players.jsx
@@ -47,7 +47,7 @@ const Players = () => {
   return (
     <div className="p-6 bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600 min-h-screen">
       <NavBar />
-      <SpiritButton />
+      {/* <SpiritButton /> */}
       {/* Plaers list + Image */}
       <div className="flex items-center justify-center  mb-6 space-x-4 mt-30">
           <h1 className="text-3xl font-bold text-gray-900">Players List</h1>

--- a/spirit11/client/src/pages/TeamAndSelection.jsx
+++ b/spirit11/client/src/pages/TeamAndSelection.jsx
@@ -112,7 +112,7 @@ const TeamAndSelection = () => {
   return (
     <div className="min-h-screen p-6 bg-gradient-to-r from-gray-200 via-gray-400 to-gray-600 text-white">
       <Navbar />
-      <SpiritButton />
+      {/* <SpiritButton /> */}
       <h1 className="text-5xl font-bold text-center mb-6 mt-30 p-4">
         🏏 Player Selection & My Team
       </h1>


### PR DESCRIPTION
This pull request includes changes to the `SpiritButton` component and its usage across multiple pages in the `spirit11` client. The most important changes involve commenting out the `SpiritButton` component in several pages and adding a new CSS class to the button element.

Changes to `SpiritButton` component:

* [`spirit11/client/src/components/SpiritButton.jsx`](diffhunk://#diff-d9e5b65ac6599eb0d3fa8c7cfe47d48bff9174d4a5b24e56eae5c22148ce14a2L14-R14): Added `cursor-pointer` class to the button element to change the cursor style on hover.

Usage of `SpiritButton` component:

* [`spirit11/client/src/pages/AddPlayer.jsx`](diffhunk://#diff-1ec9e6b9b3a90a588b16ed063f2e30848ce6fbd1556e2402bd9a8061e08c59eaL80-R80): Commented out the `SpiritButton` component.
* [`spirit11/client/src/pages/Budget.jsx`](diffhunk://#diff-c4ba6919626f18c3414039842fa9048f8dc7e2922f8b495b3f4341f2b051b737L45-R45): Commented out the `SpiritButton` component.
* [`spirit11/client/src/pages/Leaderboard.jsx`](diffhunk://#diff-aa8fa3e954d3ef55e16850e102f4f8365a49dbb4011e8e0a5f0061ddc9fdc926L40-R40): Commented out the `SpiritButton` component.
* [`spirit11/client/src/pages/Players.jsx`](diffhunk://#diff-553b85f41f2a790b23f4b1805ace6d5e1ebae1ecd13b963ac958e833ca7444b7L50-R50): Commented out the `SpiritButton` component.
* [`spirit11/client/src/pages/TeamAndSelection.jsx`](diffhunk://#diff-7de42f5923a0050bd93c9a27460bee5b41a268eecf4760de7ae796c976fbfcceL115-R115): Commented out the `SpiritButton` component.